### PR TITLE
feat: color preview (support hex and rgb)

### DIFF
--- a/app/dashboard/color-preview/ColorPreview.tsx
+++ b/app/dashboard/color-preview/ColorPreview.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import Input from "@/components/Input";
+import { useCallback, useState } from "react";
+import { LuClipboardCopy } from "react-icons/lu";
+
+export default function ColorPreview() {
+  const [colorCode, setColorCode] = useState("");
+
+  const rgbToHex = useCallback(
+    (r: number, g: number, b: number) => {
+      const fullHexCode = [r, g, b]
+        .map((x) => {
+          const hex = x.toString(16);
+          return hex.length === 1 ? "0" + hex : hex;
+        })
+        .join("");
+
+      return "#" + fullHexCode;
+    },
+    [colorCode],
+  );
+
+  const hexToRgb = useCallback(
+    (hexCode: string) => {
+      const rgbArr = hexCode
+        .replace(
+          "/^#?([a-fd])([a-fd])([a-fd])$/i",
+          (m, r, g, b) => "#" + r + r + g + g + b + b,
+        )
+        .substring(1)
+        .match(/.{2}/g)
+        ?.map((x) => parseInt(x, 16));
+
+      return `rgb(${rgbArr?.[0]}, ${rgbArr?.[1] || rgbArr?.[0]}, ${rgbArr?.[2] || rgbArr?.[1] || rgbArr?.[0]
+        })`;
+    },
+    [colorCode],
+  );
+
+  const getColorCodeType = (colorCode: string, type: "HEX" | "RGB" | "HSL") => {
+    switch (type) {
+      case "HEX":
+        if (colorCode.includes("#")) {
+          return colorCode;
+        }
+
+        if (colorCode.includes("rgb")) {
+          const [r, g, b] = colorCode.match(/\d+/g) ?? ["255", "255", "255"];
+
+          return rgbToHex(+r, +g, +b);
+        }
+        break;
+      case "RGB":
+        if (colorCode.includes("rgb")) {
+          return colorCode;
+        }
+
+        if (colorCode.includes("#")) {
+          return hexToRgb(colorCode);
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div className="w-3/4 mx-auto pb-10">
+      <Input
+        type="text"
+        onChange={(e) => setColorCode(e.target.value)}
+        placeholder="Masukan kode disini"
+        label="Color Code"
+      />
+      <div className="w-full grid lg:grid-cols-2 grid-cols-1 gap-4 mt-4">
+        <div
+          className="w-full aspect-square"
+          style={{
+            backgroundColor: `${colorCode || "#fff"}`,
+          }}
+        />
+
+        <div>
+          <h3>Color Info Detail</h3>
+          <ul className="mt-2 space-y-2 text-lg">
+            <li className="flex justify-between w-full">
+              <p>hex</p>
+              <p className="flex items-center gap-2">
+                <span className="select-all">
+                  {getColorCodeType(colorCode, "HEX") || "#"}
+                </span>
+                <LuClipboardCopy
+                  onClick={() => {
+                    navigator.clipboard.writeText(
+                      getColorCodeType(colorCode, "HEX") || "#",
+                    );
+                    alert("Hex Color Code Copied!");
+                  }}
+                  className="hover:opacity-75 w-5 h-5"
+                />
+              </p>
+            </li>
+
+            <li className="flex justify-between w-full">
+              <p>rgb</p>
+              <p className="flex items-center gap-2">
+                <span className="select-all">
+                  {getColorCodeType(colorCode, "RGB") || "rgb()"}
+                </span>
+                <LuClipboardCopy
+                  onClick={() => {
+                    navigator.clipboard.writeText(
+                      getColorCodeType(colorCode, "RGB") || "rgb()",
+                    );
+                    alert("RGB Color Code Copied!");
+                  }}
+                  className="hover:opacity-75 w-5 h-5"
+                />
+              </p>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/color-preview/page.tsx
+++ b/app/dashboard/color-preview/page.tsx
@@ -1,0 +1,20 @@
+import { MotionOpacity } from "@/components/Motion";
+import { Title } from "@/components/Title";
+import ColorPreview from "./ColorPreview";
+
+export default function Pages() {
+  return (
+    <>
+      <MotionOpacity>
+        <section className="flexCenterMargin">
+          <Title
+            title="Color Preview"
+            desc="Translate your hex/rgb/hsl code to actual colors"
+            highlight="Generator"
+          />
+        </section>
+      </MotionOpacity>
+      <ColorPreview />
+    </>
+  );
+}

--- a/utils/feature.ts
+++ b/utils/feature.ts
@@ -5,8 +5,8 @@ import { PiWhatsappLogoLight } from "react-icons/pi";
 import { AiFillCalculator } from "react-icons/ai";
 import { WiEarthquake } from "react-icons/wi";
 import { FiUser } from "react-icons/fi";
-import { MdPassword, MdColorLens} from "react-icons/md";
-import { LuStickyNote } from "react-icons/lu";
+import { MdPassword, MdColorLens } from "react-icons/md";
+import { LuBrush, LuStickyNote } from "react-icons/lu";
 import { GiThink } from "react-icons/gi";
 import { MdOutlineScore } from "react-icons/md";
 
@@ -76,5 +76,10 @@ export const feature: Feature[] = [
     title: "words counter",
     link: "/dashboard/words-counter",
     icon: MdOutlineScore,
-  }
+  },
+  {
+    title: "color preview",
+    link: "/dashboard/color-preview",
+    icon: LuBrush,
+  },
 ];


### PR DESCRIPTION
Translate kode warna dari hexa atau rgb lalu membuat kotak di bawah nya berwarna sesuai dengan kode warna yang sudah di translate secara realtime

pertama kali kontribusi ke project open source ni bang, maap klo ada salah salah wkwkwk

![ZTools — Mozilla Firefox 21_09_2023 14_32_52](https://github.com/Zeddnyx/ZTools/assets/77385046/7d02ff5d-7d65-4405-8af4-35596e38c749)
